### PR TITLE
Forced time-zone in backend to Europe/Oslo

### DIFF
--- a/server/settings.py
+++ b/server/settings.py
@@ -206,5 +206,7 @@ NO_TAKES = True
 
 FTP_TIMEOUT = 30
 
+DEFAULT_TIMEZONE = "Europe/Oslo"
+
 # FIXME: temporary fix for SDNTB-344, need to be removed once SDESK-439 is implemented
 INGEST_SKIP_IPTC_CODES = True


### PR DESCRIPTION
a forced time-zone in settings avoid depending on local timezone in
backend, and avoid issues like SDNTB-347 .