### PR TITLE
[FORMATTER] [NITF] fix crash when featuremedia (or featureimage) is None

### DIFF
--- a/server/ntb/publish/ntb_nitf.py
+++ b/server/ntb/publish/ntb_nitf.py
@@ -309,13 +309,13 @@ class NTBNITFFormatter(NITFFormatter):
         except KeyError:
             pass
         else:
-            try:
-                media_data.append(associations['featureimage'])
-            except KeyError:
-                try:
-                    media_data.append(associations['featuremedia'])
-                except KeyError:
-                    pass
+            feature_image = associations.get('featureimage')
+            if feature_image is not None:
+                media_data.append(feature_image)
+            else:
+                feature_media = associations.get('featuremedia')
+                if feature_media is not None:
+                    media_data.append(feature_media)
 
         def repl_embedded(match):
             """embedded in body_html handling"""

--- a/server/ntb/tests/publish/ntb_nitf_test.py
+++ b/server/ntb/tests/publish/ntb_nitf_test.py
@@ -374,6 +374,22 @@ class NTBNITFFormatterTest(TestCase):
         body_content = nitf_xml.find("body/body.content")
         self.assertEqual(etree.tostring(body_content).replace(b'\n', b'').replace(b' ', b''), expected)
 
+    @mock.patch.object(SubscribersService, 'generate_sequence_number', lambda self, subscriber: 1)
+    def test_355(self):
+        """SDNTB-355 regression test
+
+        formatter should not crash when featuremedia is None
+        """
+        article = copy.deepcopy(self.article)
+        article['associations']['featuremedia'] = None
+        formatter_output = self.formatter.format(article, {'name': 'Test NTBNITF'})
+        doc = formatter_output[0]['formatted_item']
+        nitf_xml = etree.fromstring(doc)
+        # the test will raise an exception during self.formatter.format if SDNTB-355 bug is still present
+        # but we check in addition that media counter is as expected
+        media_counter = nitf_xml.find('head').find('meta[@name="NTBBilderAntall"]')
+        self.assertEqual(media_counter.get('content'), '2')
+
     def test_filename(self):
         filename = self.nitf_xml.find('head/meta[@name="filename"]')
         datetime = NOW.astimezone(self.tz).strftime("%Y-%m-%d_%H-%M-%S")


### PR DESCRIPTION
featuremedia can sometimes be None (video added then removed?), which
was not expected in NITF formatter, resulting in a crash.

This commit fix this.

SDNTB-355