### PR TITLE
[FORMATTER] [NITF] remove blank text on body_html parsing

### DIFF
--- a/server/ntb/publish/ntb_nitf.py
+++ b/server/ntb/publish/ntb_nitf.py
@@ -329,7 +329,7 @@ class NTBNITFFormatter(NITFFormatter):
         # and no more embedded in html
 
         # regular content
-        parser = etree.XMLParser(recover=True)
+        parser = etree.XMLParser(recover=True, remove_blank_text=True)
         try:
             html_elts = etree.fromstring(''.join(('<div>', html, '</div>')), parser)
         except Exception as e:


### PR DESCRIPTION
if blank text is not removed, pretty print will not work as expected
    because it can't know if blank text is significant or not. Using
    remove_blank_text when parsing body_html should fix the problem.

cf. http://lxml.de/FAQ.html#why-doesn-t-the-pretty-print-option-reformat-my-xml-output

SDNTB-328