### PR TITLE
[FORMATTER] [NITF] minor changes for HTML2NITF

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,4 +1,4 @@
 gunicorn==19.6.0
 honcho==0.6.6
 newrelic>=2.66,<2.67
-git+git://github.com/superdesk/superdesk-core.git@ba7d2c0#egg=Superdesk-Core
+git+git://github.com/superdesk/superdesk-core.git@994045d#egg=Superdesk-Core


### PR DESCRIPTION
Following changes in superdesk-core, HTML2NITF is no more a class
attribute but it is an instance one. deepcopy is not needed anymore,
neither is staticmethod decorator for p_filter.

SDNTB-398