### PR TITLE
[SEARCH PROVIDER] [SCANPIX] don't get subscription from query anymore

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,5 +1,5 @@
 {
     "dependencies": {
-        "superdesk-core": "superdesk/superdesk-client-core#15ead18"
+        "superdesk-core": "superdesk/superdesk-client-core#7681f4b"
     }
 }

--- a/server/ntb/scanpix/scanpix_datalayer.py
+++ b/server/ntb/scanpix/scanpix_datalayer.py
@@ -42,14 +42,14 @@ SCANPIX_TZ = 'Europe/Oslo'
 def extract_params(query, names):
     if isinstance(names, str):
         names = [names]
-    findall = re.findall('([\w]+):\(([-\w\s*]+)\)', query)
+    findall = re.findall(r'([\w]+):\(([-\w\s*]+)\)', query)
     params = {name: value for (name, value) in findall if name in names}
     for name, value in findall:
         query = query.replace('%s:(%s)' % (name, value), '')
     query = query.strip()
     # escape dashes
     for name, value in params.items():
-        params[name] = value.replace('-', '\-')
+        params[name] = value.replace('-', r'\-')
     if query:
         params['q'] = query
     return params
@@ -117,17 +117,13 @@ class ScanpixDatalayer(DataLayer):
                     data['clearEdge'] = True
 
             # subscription
-            try:
-                data['subscription'] = extract_params(query, 'subscription')['subscription']
-            except KeyError:
-                data['subscription'] = 'subscription'  # this is requested as a default value
+            data['subscription'] = 'subscription'  # this is requested as a default value
 
+            # data['subscription'] is always equal to 'subscription', but we keep the test in case
+            # of the behaviour is changed again in the future.
             if 'ntbtema' in resource and data['subscription'] == 'subscription':
                 # small hack for SDNTB-250
                 data['subscription'] = 'punchcard'
-
-            if data['subscription'] == 'all':
-                del data['subscription']
 
             text_params = extract_params(query, ('headline', 'keywords', 'caption', 'text'))
             # combine all possible text params to use the q field.


### PR DESCRIPTION
subscription option has been removed from UI, so there is no need to get
if from query anymore.

the ntbtema hack is kept, so the behaviours doesn't change