### PR TITLE
[FORMATTER] [NITF] fix exception when body_html is None

### DIFF
--- a/server/ntb/io/feed_parsers/wufoo.py
+++ b/server/ntb/io/feed_parsers/wufoo.py
@@ -70,9 +70,6 @@ class WufooArticle(dict):
 
 
 class WufooFeedParser(FeedParser):
-    """
-    NITF Parser extension for Press Association, it maps the category meta tag to an anpa category
-    """
 
     NAME = 'wufoo'
 

--- a/server/ntb/publish/ntb_nitf.py
+++ b/server/ntb/publish/ntb_nitf.py
@@ -329,7 +329,7 @@ class NTBNITFFormatter(NITFFormatter):
                     media_data.append(data)
             return ''
 
-        html = self.strip_invalid_chars(EMBED_RE.sub(repl_embedded, article.get('body_html')))
+        html = self.strip_invalid_chars(EMBED_RE.sub(repl_embedded, article.get('body_html') or ''))
         # it is a request from SDNTB-388 to use normal space instead of non breaking spaces
         # so we do this replace
         html = html.replace('&nbsp;', ' ')

--- a/server/ntb/tests/publish/ntb_nitf_test.py
+++ b/server/ntb/tests/publish/ntb_nitf_test.py
@@ -548,3 +548,19 @@ class NTBNITFFormatterTest(TestCase):
         # but we check in addition that media counter is as expected (same as for test_355)
         media_counter = nitf_xml.find('head').find('meta[@name="NTBBilderAntall"]')
         self.assertEqual(media_counter.get('content'), '3')
+
+    @mock.patch.object(SubscribersService, 'generate_sequence_number', lambda self, subscriber: 1)
+    def test_body_none(self):
+        article = copy.deepcopy(self.article)
+        article['body_html'] = None
+        formatter_output = self.formatter.format(article, {'name': 'Test NTBNITF'})
+        # the test will raise an exception during self.formatter.format if SDNTB-420 bug is still present
+        # but we also check that body.content is there
+        doc = formatter_output[0]['encoded_item']
+        nitf_xml = etree.fromstring(doc)
+        expected = ('<body.content><pclass="lead"lede="true">Thisistheabstract</p><pclass="txt">footertext</p><mediame'
+                    'dia-type="image"><media-referencemime-type="image/jpeg"source="test_id"/><media-caption>testfeatu'
+                    'remedia</media-caption></media></body.content>')
+        content = etree.tostring(nitf_xml.find('body/body.content'),
+                                 encoding="unicode").replace('\n', '').replace(' ', '')
+        self.assertEqual(content, expected)


### PR DESCRIPTION
NTB NITF formatter was raising an exception when body_html was None or
not set, this commit fixes it.

SDNTB-420