### PR TITLE
disable elastic settings update when running manage.py

### DIFF
--- a/server/manage.py
+++ b/server/manage.py
@@ -15,7 +15,7 @@ import superdesk
 from flask.ext.script import Manager
 from app import get_app
 
-app = get_app(init_elastic=True)
+app = get_app(init_elastic=False)  # disable elastic updates
 manager = Manager(app)
 
 if __name__ == '__main__':


### PR DESCRIPTION
- there are no changes needed, so avoid any downtime when updating