### PR TITLE
[FEED PARSER][STT] fixed call of parent parse() method

### DIFF
--- a/server/ntb/io/feed_parsers/stt_newsml.py
+++ b/server/ntb/io/feed_parsers/stt_newsml.py
@@ -30,9 +30,8 @@ class NTBSTTNewsMLFeedParser(STTNewsMLFeedParser):
         return xml.tag.endswith('newsItem')
 
     def parse(self, xml, provider=None):
-        self.root = xml
         try:
-            item = self.parse_item(xml)
+            item = super().parse(xml, provider)[0]
             # SDNTB-462 requires that slugline is removed
             del item['slugline']
             sport = bool(self.root.xpath('//iptc:subject[@type="cpnat:abstract" and @qcode="sttsubj:15000000"]',


### PR DESCRIPTION
NTB variant of STT parser was not correctly calling parent parse()
method, this patch fixes it.

SDNTB-482