### PR TITLE
[FEED PARSER] [NTF NIFS] decode data on reception

### DIFF
--- a/server/ntb/io/feed_parsers/ntb_nifs.py
+++ b/server/ntb/io/feed_parsers/ntb_nifs.py
@@ -42,7 +42,7 @@ class NTBNIFSFeedParser(FeedParser):
             sport_map = config.NIFS_SPORT_MAP
         except KeyError:
             raise SuperdeskIngestError.notConfiguredError(Exception('NIFS maps are not found in settings'))
-        events = json.loads(data)
+        events = json.loads(data.decode('utf-8', 'ignore'))
         items = []
         try:
             for event in events:

--- a/server/ntb/tests/io/feed_parsers/nifs_events_test.py
+++ b/server/ntb/tests/io/feed_parsers/nifs_events_test.py
@@ -25,7 +25,7 @@ class BaseNIFSTestCase(TestCase):
         dirname = os.path.dirname(os.path.realpath(__file__))
         fixture = os.path.normpath(os.path.join(dirname, '../fixtures', self.filename))
         self.parser = NTBNIFSFeedParser()
-        with open(fixture) as f:
+        with open(fixture, 'rb') as f:
             self.items = self.parser.parse(f.read())
 
 


### PR DESCRIPTION
Python 3.6 accept to load json from bytes if they are encoded in UTF-8,
but Python 3.5 doesn't, resulting in crash. This patch make NTB NIFS feed
parser compatible with Python 3.5

SDNTB-480