### PR TITLE
[FEED PARSER] [WUFOO] Don't fail on missing field

### DIFF
--- a/server/ntb/macros/nob_NO_publish_macro.py
+++ b/server/ntb/macros/nob_NO_publish_macro.py
@@ -9,15 +9,19 @@ from requests.auth import HTTPBasicAuth
 
 
 def nob_NO_publish_macro(item, **kwargs):
-    creds = HTTPBasicAuth('superdesk', 'babel')
-    payload = {k: item.get(k) for k in item if k in ('guid', 'headline', 'body_html', 'body_text', 'abstract', 'description_html', 'description_text')}
-    #payload=item
-    requests.post('http://api.smalldata.no:8080/publish', data=payload, timeout=(10, 30), auth=creds)
+    creds = HTTPBasicAuth("superdesk", "babel")
+    payload = {
+        k: item.get(k)
+        for k in item
+        if k in ("guid", "headline", "body_html", "body_text", "abstract", "description_html", "description_text")
+    }
+    # payload=item
+    requests.post("http://api.smalldata.no:8080/publish", data=payload, timeout=(10, 30), auth=creds)
     return item
 
 
-name = 'Bokmal to Nynorsk Publish Macro'
-label = 'Språkvask - Lagre'
+name = "Bokmal to Nynorsk Publish Macro"
+label = "Språkvask - Lagre"
 callback = nob_NO_publish_macro
-access_type = 'frontend'
-action_type = 'direct'
+access_type = "frontend"
+action_type = "direct"

--- a/server/ntb/macros/nob_NO_translate_macro.py
+++ b/server/ntb/macros/nob_NO_translate_macro.py
@@ -8,18 +8,22 @@ from requests.auth import HTTPBasicAuth
 
 
 def nob_NO_translate_macro(item, **kwargs):
-    creds = HTTPBasicAuth('superdesk', 'babel')
-    payload = {k: item.get(k) for k in item if k in ('guid', 'headline', 'body_html', 'body_text', 'abstract', 'description_html', 'description_text')}
-    r = requests.post('http://api.smalldata.no:8080/translate', data=payload, timeout=(10, 30), auth=creds)
+    creds = HTTPBasicAuth("superdesk", "babel")
+    payload = {
+        k: item.get(k)
+        for k in item
+        if k in ("guid", "headline", "body_html", "body_text", "abstract", "description_html", "description_text")
+    }
+    r = requests.post("http://api.smalldata.no:8080/translate", data=payload, timeout=(10, 30), auth=creds)
     if r.status_code == 200:
         item.update(r.json())
     return item
 
 
-name = 'Bokmal to Nynorsk Translate Macro'
-label = 'Omsett NB til NN'
+name = "Bokmal to Nynorsk Translate Macro"
+label = "Omsett NB til NN"
 callback = nob_NO_translate_macro
-access_type = 'frontend'
-action_type = 'direct'
-from_languages = ['nb-NO']
-to_languages = ['nn-NO']
+access_type = "frontend"
+action_type = "direct"
+from_languages = ["nb-NO"]
+to_languages = ["nn-NO"]

--- a/server/ntb/tests/io/feed_parsers/wufoo_tests.py
+++ b/server/ntb/tests/io/feed_parsers/wufoo_tests.py
@@ -93,3 +93,14 @@ class Wufoo(TestCase):
                     'cTFocGR3ZzkxaDZ1Ymwx/SIioTwuslashL4koY%3D/photo_test.jpg">photo</a></p>')
         item = self.parser.parse_article(article)
         self.assertEqual(item['body_html'], expected)
+
+    def test_missing_field(self):
+        """we check that ingest is not crashing if fields are missing (SDNTB-509)"""
+        article = copy.deepcopy(self.article)
+        for i in range(102, 106):
+            del article['Field' + str(i)]
+        expected = ('<p>biography_test\n<br/>\n<a href="https://norsktelegram.wufoo.com/cabinet/cTFocGR3ZzkxaDZ1Ymwx/SI'
+                    'ioTwuslashL4koY%3D/photo_test.jpg">photo</a></p>')
+
+        item = self.parser.parse_article(article)
+        self.assertEqual(item['body_html'], expected)

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -2,5 +2,5 @@ gunicorn==19.7.1
 honcho==1.0.1
 newrelic==2.88.1.73
 
--e git+git://github.com/superdesk/superdesk-core.git@d3be201#egg=Superdesk-Core
+-e git+git://github.com/superdesk/superdesk-core.git@2e779af#egg=Superdesk-Core
 -e git+git://github.com/superdesk/superdesk-planning.git@172071e#egg=superdesk-planning

--- a/server/setup.cfg
+++ b/server/setup.cfg
@@ -1,4 +1,4 @@
 [flake8]
 max-line-length=120
 exclude=env,bin,lib,include,src
-ignore=F811
+ignore=F811,W503


### PR DESCRIPTION
if a field is missing, an empty string is used instead.
In the case of "birth date", a warning is printed and current date is
used.

This patch also fixes code style in few files and disable W503 warning
for flake8, which is not valid anymore (PEP 8 has changed on this point).

SDNTB-509