### PR TITLE
[FEED PARSER] [NIFS] Fixed use of None in item['dates']['tz']

### DIFF
--- a/server/ntb/io/feed_parsers/ntb_nifs.py
+++ b/server/ntb/io/feed_parsers/ntb_nifs.py
@@ -150,7 +150,7 @@ class NTBNIFSFeedParser(FeedParser):
 
                 item = {'guid': event['uid'],
                         ITEM_TYPE: CONTENT_TYPE.EVENT,
-                        'dates': {'start': event_start, 'end': event_end, 'tz': None},
+                        'dates': {'start': event_start, 'end': event_end, 'tz': ''},
                         'name': name,
                         'slugline': sport,
                         'subject': subject,

--- a/server/ntb/tests/io/feed_parsers/nifs_events_test.py
+++ b/server/ntb/tests/io/feed_parsers/nifs_events_test.py
@@ -68,7 +68,7 @@ class NifsTestCase(BaseNIFSTestCase):
         self.assertEqual(item['slugline'], "Fotball")
         self.assertEqual(item['dates']['start'].isoformat(), "2018-03-11T18:00:00+01:00")
         self.assertEqual(item['dates']['end'].isoformat(), "2018-03-11T20:00:00+01:00")
-        self.assertIsNone(item['dates']['tz'])
+        self.assertEqual(item['dates']['tz'], '')
         self.assertEqual(item['anpa_category'][0], {'qcode': 'n', 'name': 'Nyhetstjenesten'})
         self.assertEqual(item['calendars'][0]['qcode'], "sport")
         self.assertIn({'name': 'Sport', 'qcode': 'Sport', 'scheme': 'category'}, item['subject'])


### PR DESCRIPTION
item['dates']['tz] was using None while the schema uses a non nullable
string.

This patch fixes it by using empty string instead.

SDNTB-557