### PR TITLE
[FEED PARSER] [SOLITA] added missing genre + some improvments

### DIFF
--- a/server/ntb/io/feed_parsers/solita.py
+++ b/server/ntb/io/feed_parsers/solita.py
@@ -35,6 +35,10 @@ class SolitaFeedParser(XMLFeedParser):
         super().__init__()
 
         self.default_mapping = {
+            'guid': {
+                'xpath': './@id',
+                'filter': lambda i: "solita-{}-{}".format(self.provider['_id'], i)
+            },
             'headline': self.get_headline,
             'slugline': {
                 'xpath': './@id',
@@ -42,8 +46,10 @@ class SolitaFeedParser(XMLFeedParser):
             },
             'abstract': 'leadtext',
             'body_html': self.get_body,
-            'firstpublished': {'xpath': 'publicationDate/text()',
-                               'filter': dateutil.parser.parse},
+            'firstpublished': {
+                'xpath': 'publicationDate/text()',
+                'filter': dateutil.parser.parse
+            },
             'original_source': 'publisher/@id',
 
         }
@@ -52,11 +58,13 @@ class SolitaFeedParser(XMLFeedParser):
         return xml.tag.endswith('release')
 
     def parse(self, xml, provider=None):
+        self.provider = provider
         item = {
             ITEM_TYPE: CONTENT_TYPE.TEXT,  # set the default type.
             'guid': generate_guid(type=GUID_NEWSML),
             'versioncreated': utcnow(),
             'anpa_category': [{"name": "Formidlingstjenester", "qcode": "r"}],
+            'genre': [{"name": "Fulltekstmeldinger", "qcode": "Fulltekstmeldinger"}],
             'subject': [{'qcode': 'PRM-NTB',
                          'name': 'PRM-NTB',
                          'scheme': 'category'}],
@@ -96,15 +104,15 @@ class SolitaFeedParser(XMLFeedParser):
                 url=url,
                 caption=e(document_elt.findtext('title') or url)))
         if documents:
-            body_list.extend(["<p>", "<br>".join(documents), "</p>"])
+            body_list.extend(["<h2>Dokumenter</h2><p>", "<br>".join(documents), "</p>"])
 
         # contacts
         for contact_elt in root_elt.xpath('contacts/contact'):
             body_list.append(
-                '<p>Kontacter:'
-                '<name>{name}</name>'
-                '<title>{title}</title>'
-                '<phone>{phone}</phone>'
+                '<h2>Kontacter</h2>'
+                '<p><name>{name}</name><br>'
+                '<title>{title}</title><br>'
+                '<phone>{phone}</phone><br>'
                 '<email>{email}</email>'
                 '</p>'.format(
                     name=e(contact_elt.findtext('name', '')),

--- a/server/ntb/tests/io/feed_parsers/__init__.py
+++ b/server/ntb/tests/io/feed_parsers/__init__.py
@@ -29,7 +29,7 @@ class XMLParserTestCase(TestCase):
     def _run_parse(self):
         dirname = os.path.dirname(os.path.realpath(__file__))
         fixture = os.path.normpath(os.path.join(dirname, '../fixtures', self.filename))
-        provider = {'name': 'Test'}
+        provider = {'_id': '123123', 'name': 'Test'}
         with open(fixture, 'rb') as f:
             self.xml = f.read()
             self.xml_root = etree.fromstring(self.xml)

--- a/server/ntb/tests/io/feed_parsers/solita_test.py
+++ b/server/ntb/tests/io/feed_parsers/solita_test.py
@@ -29,11 +29,13 @@ class STTTestCase(BaseSolitaTestCase):
     def test_content(self):
         """Check majors metadata"""
         item = self.item[0]
+        self.assertEqual(item['guid'], 'solita-123123-17854111')
         self.assertEqual(item['type'], 'text')
         self.assertEqual(item['firstpublished'].isoformat(), '2018-09-28T11:15:00')
         self.assertEqual(item['headline'], 'PRM: Nye Veier / Signerte veikontrakt på 4 mrd. i Trøndelag')
         self.assertEqual(item['slugline'], 'PRM-NTB-17854111')
         self.assertEqual(item['anpa_category'], [{"name": "Formidlingstjenester", "qcode": "r"}])
+        self.assertEqual(item['genre'], [{"name": "Fulltekstmeldinger", "qcode": "Fulltekstmeldinger"}])
 
         self.assertIn(
             {'qcode': 'PRM-NTB',
@@ -127,12 +129,12 @@ class STTBodyTestCase(BaseSolitaTestCase):
             'ate barnehagekjedene. Form&aring;let vil v&aelig;re &aring; legge til rette for en barnehagesektor med lan'
             'gsiktige og seri&oslash;se eiere, som driver barnehager av h&oslash;y kvalitet og som er opptatt av innova'
             'sjon og kostnadseffektiv drift.</p>\n        <p>Utvalget som n&aring; nedsette vil v&aelig;re et viktig su'
-            'pplement til disse arbeidene.</p>\n<p>Kontacter:<name>Pressevakt NFD</name><title>Pressevakta er betent me'
-            'llom 8.00 - 15.45 på kvardagar (8.00-15.00 om sumaren).</title><phone>902 51 303 (ikkje SMS)</phone><email'
-            '>media@nfd.dep.no</email></p>\n<p>Les hele denne saken fra <name>Nærings- og fiskeridepartementet</name> p'
-            'å NTB info<br><a href="https://www.ntbinfo.no/pressemelding/ekspertutvalg-skal-se-pa-bruk-av-private-velfe'
-            'rdsleverandorer?releaseId=17854144">https://www.ntbinfo.no/pressemelding/ekspertutvalg-skal-se-pa-bruk-av-'
-            'private-velferdsleverandorer?releaseId=17854144</a></p>')
+            'pplement til disse arbeidene.</p>\n<h2>Kontacter</h2><p><name>Pressevakt NFD</name><br><title>Pressevakta '
+            'er betent mellom 8.00 - 15.45 på kvardagar (8.00-15.00 om sumaren).</title><br><phone>902 51 303 (ikkje SM'
+            'S)</phone><br><email>media@nfd.dep.no</email></p>\n<p>Les hele denne saken fra <name>Nærings- og fiskeride'
+            'partementet</name> på NTB info<br><a href="https://www.ntbinfo.no/pressemelding/ekspertutvalg-skal-se-pa-b'
+            'ruk-av-private-velferdsleverandorer?releaseId=17854144">https://www.ntbinfo.no/pressemelding/ekspertutvalg'
+            '-skal-se-pa-bruk-av-private-velferdsleverandorer?releaseId=17854144</a></p>')
 
 
 class STTDocumentsTestCase(BaseSolitaTestCase):
@@ -167,10 +169,11 @@ class STTDocumentsTestCase(BaseSolitaTestCase):
             'ene. Spesielt Detaljhandel, Lagring og Transport merker presset. (foto for fri bruk til saken)</a><br><a h'
             'ref="https://www.ntbinfo.no/data/images/00749/e303f05c-30ad-4821-8862-d0f1f27d484a.jpg">– Det er spesielt '
             'noen bransjer som merker presset. Butikkene har for lengst merket kampen mot netthandelen og sliter med la'
-            've marginer, forteller Per Einar Ruud i data- og analyseselskapet Bisnode.</a>\n</p>\n<p>\n<a href="https:'
-            '//www.ntbinfo.no/data/attachments/00203/fa42f1c1-aaa5-4ec1-908d-8b38a100bfab.pptx">Konkurser februar 2019.'
-            'pptx</a>\n</p>\n<p>Kontacter:<name>Per Einar Ruud i Bisnode</name><title>Kredittøkonom, Bisnode</title><ph'
-            'one>+47 92 40 10 04\u2028</phone><email>per.einar.ruud@bisnode.com</email></p>\n<p>Les hele denne saken fr'
-            'a <name>Bisnode</name> på NTB info<br><a href="https://www.ntbinfo.no/pressemelding/nedgang-men-fortsatt-h'
-            'oye-konkurstall-med-bransje--og-fylkesoversikt?releaseId=17861325">https://www.ntbinfo.no/pressemelding/ne'
-            'dgang-men-fortsatt-hoye-konkurstall-med-bransje--og-fylkesoversikt?releaseId=17861325</a></p>')
+            've marginer, forteller Per Einar Ruud i data- og analyseselskapet Bisnode.</a>\n</p>\n<h2>Dokumenter</h2><'
+            'p>\n<a href="https://www.ntbinfo.no/data/attachments/00203/fa42f1c1-aaa5-4ec1-908d-8b38a100bfab.pptx">Konk'
+            'urser februar 2019.pptx</a>\n</p>\n<h2>Kontacter</h2><p><name>Per Einar Ruud i Bisnode</name><br><title>Kr'
+            'edittøkonom, Bisnode</title><br><phone>+47 92 40 10 04\u2028</phone><br><email>per.einar.ruud@bisnode.com<'
+            '/email></p>\n<p>Les hele denne saken fra <name>Bisnode</name> på NTB info<br><a href="https://www.ntbinfo.'
+            'no/pressemelding/nedgang-men-fortsatt-hoye-konkurstall-med-bransje--og-fylkesoversikt?releaseId=17861325">'
+            'https://www.ntbinfo.no/pressemelding/nedgang-men-fortsatt-hoye-konkurstall-med-bransje--og-fylkesoversikt?'
+            'releaseId=17861325</a></p>')


### PR DESCRIPTION
guid is now build using `provider_id` and `release_id`, this way it is
unique per provider, and avoid ingesting twice the same item.

added missing "genre"

use level heading for contacts and documents.

SDNTB-561