### PR TITLE
[FEED PARSER][SOLITA]add images to association + embedded marquer

### DIFF
--- a/server/ntb/publish/ntb_nitf.py
+++ b/server/ntb/publish/ntb_nitf.py
@@ -20,7 +20,7 @@ from flask import current_app as app
 
 from superdesk import etree as sd_etree
 from superdesk.metadata.item import ITEM_TYPE, CONTENT_TYPE
-from superdesk.publish.formatters.nitf_formatter import NITFFormatter
+from superdesk.publish.formatters.nitf_formatter import NITFFormatter, EraseElement
 from superdesk.publish.publish_service import PublishService
 from superdesk.errors import FormatterError
 
@@ -131,6 +131,8 @@ class NTBNITFFormatter(NITFFormatter):
 
         'txt' is only used immediatly after "hl2" elem, txt-ind in all other cases
         """
+        if p_elem.get('class') == 'ntb-media':
+            raise EraseElement("Element need to be erased")
         parent = p_elem.find('..')
         children = list(parent)
         idx = children.index(p_elem)
@@ -291,15 +293,19 @@ class NTBNITFFormatter(NITFFormatter):
         elif language == 'nn-NO':
             org.text = 'NPK'
 
-    def _add_media(self, body_content, type_, mime_type, source, caption, featured):
+    def _add_media(self, body_content, type_, mime_type, source, caption, featured=None, cls=None, alternate_text=None):
         media = etree.SubElement(body_content, 'media')
         media.attrib['media-type'] = type_
+        if cls:
+            media.set('class', cls)
         if featured is not None:
-            media.attrib['class'] = 'illustrasjonsbilde'
+            media.set('class', 'illustrasjonsbilde')
         media_reference = etree.SubElement(media, 'media-reference')
         if mime_type is not None:
-            media_reference.attrib['mime-type'] = mime_type
-        media_reference.attrib['source'] = source
+            media_reference.set('mime-type', mime_type)
+        if alternate_text is not None:
+            media_reference.set('alternate-text', alternate_text)
+        media_reference.set('source', source)
         media_caption = etree.SubElement(media, 'media-caption')
         media_caption.text = caption
 
@@ -450,7 +456,28 @@ class NTBNITFFormatter(NITFFormatter):
                 mime_type = 'image/jpeg' if type_ == 'image' or type_ == 'grafikk' else 'video/mpeg'
             caption = self.strip_invalid_chars(data.get('description_text'))
             self._add_media(body_content, type_, mime_type, source, caption, featured)
-        self._add_meta_media_counter(head, len(media_data))
+        media_counter = len(media_data)
+
+        # ntb-media
+        try:
+            ntb_media = article['extra']['ntb_media']
+        except KeyError:
+            pass
+        else:
+            for data in ntb_media:
+                mime_type = data['mime_type']
+                self._add_media(
+                    body_content=body_content,
+                    type_=mime_type.split('/')[0],
+                    mime_type=mime_type,
+                    source=data['url'],
+                    caption=data['description_text'],
+                    cls='prs',
+                    alternate_text='http://www.ntbinfo.no/',
+                )
+                media_counter += 1
+
+        self._add_meta_media_counter(head, media_counter)
 
     def _format_body_end(self, article, body_end):
         try:

--- a/server/ntb/tests/io/feed_parsers/solita_test.py
+++ b/server/ntb/tests/io/feed_parsers/solita_test.py
@@ -35,7 +35,8 @@ class STTTestCase(BaseSolitaTestCase):
         self.assertEqual(item['headline'], 'PRM: Nye Veier / Signerte veikontrakt på 4 mrd. i Trøndelag')
         self.assertEqual(item['slugline'], 'PRM-NTB-17854111')
         self.assertEqual(item['anpa_category'], [{"name": "Formidlingstjenester", "qcode": "r"}])
-        self.assertEqual(item['genre'], [{"name": "Fulltekstmeldinger", "qcode": "Fulltekstmeldinger"}])
+        self.assertEqual(item['genre'], [{"name": "Fulltekstmeldinger", "qcode": "Fulltekstmeldinger",
+                                          "scheme": "genre_custom"}])
 
         self.assertIn(
             {'qcode': 'PRM-NTB',
@@ -72,17 +73,37 @@ class STTTestCase(BaseSolitaTestCase):
             ' med optimalisering og utarbeidelse av reguleringsplaner i f&oslash;rste fase mellom byggherre, entrepren&'
             'oslash;r og r&aring;dgiver. Deretter lukkes kontrakten som totalentreprise i gjennomf&oslash;ringsfasen, f'
             'orklarer prosjektdirekt&oslash;r i Nye Veier Tr&oslash;ndelag, Johan Arnt Vatnan.</p>\n        <p>Byggesta'
-            'rt er planlagt i midten av 2019. Prosjektet fullf&oslash;res i 2024/2025.</p>\n<p>\n<a href="https://www.n'
-            'tbinfo.no/data/images/00775/c7bdf102-9122-4fce-b762-e34353d7a68b.jpg">https://www.ntbinfo.no/data/images/0'
-            '0775/c7bdf102-9122-4fce-b762-e34353d7a68b.jpg</a><br><a href="https://www.ntbinfo.no/data/images/00507/265'
-            '39909-564d-40dc-8298-d237b964dde9.jpg">Kontrakten ble signert i Trondheim i dag. Fra venstre: Pablo Garcia'
-            ' Caramés, finanssjef, ACCIONA Construction; Joan Gil, divisjonssjef, ACCIONA Construction; Ingrid Dahl Hov'
-            'land, adm. dir. Nye Veier og Johan Arnt Vatnan, prosjektdir. Nye Veier.</a>\n</p>\n<p>Les hele denne saken'
-            ' fra <name>Nye Veier</name> på NTB info<br><a href="https://www.ntbinfo.no/pressemelding/signerte-veikontr'
-            'akt-pa-4-mrd-i-trondelag?releaseId=17854111">https://www.ntbinfo.no/pressemelding/signerte-veikontrakt-pa-'
-            '4-mrd-i-trondelag?releaseId=17854111</a></p>')
+            'rt er planlagt i midten av 2019. Prosjektet fullf&oslash;res i 2024/2025.</p>\n<p class="ntb-media">\n<a h'
+            'ref="https://www.ntbinfo.no/data/images/00775/c7bdf102-9122-4fce-b762-e34353d7a68b.jpg">https://www.ntbinf'
+            'o.no/data/images/00775/c7bdf102-9122-4fce-b762-e34353d7a68b.jpg</a><br><a href="https://www.ntbinfo.no/dat'
+            'a/images/00507/26539909-564d-40dc-8298-d237b964dde9.jpg">Kontrakten ble signert i Trondheim i dag. Fra ven'
+            'stre: Pablo Garcia Caramés, finanssjef, ACCIONA Construction; Joan Gil, divisjonssjef, ACCIONA Constructio'
+            'n; Ingrid Dahl Hovland, adm. dir. Nye Veier og Johan Arnt Vatnan, prosjektdir. Nye Veier.</a>\n</p>\n<p>Le'
+            's hele denne saken fra <name>Nye Veier</name> på NTB info<br><a href="https://www.ntbinfo.no/pressemelding'
+            '/signerte-veikontrakt-pa-4-mrd-i-trondelag?releaseId=17854111">https://www.ntbinfo.no/pressemelding/signer'
+            'te-veikontrakt-pa-4-mrd-i-trondelag?releaseId=17854111</a></p>')
         self.assertEqual(item['urgency'], 6)
         self.assertEqual(item['ednote'], '**** NTBs PRESSEMELDINGSTJENESTE - Se www.ntbinfo.no ****')
+
+    def test_ntb_media(self):
+        item = self.item[0]
+        expected = {
+            "ntb_media": [
+                {
+                    "description_text": ("Kontrakten ble signert i Trondheim i dag. "
+                                         "Fra venstre: Pablo Garcia Caramés, "
+                                         "finanssjef, ACCIONA Construction; Joan "
+                                         "Gil, divisjonssjef, ACCIONA Construction; "
+                                         "Ingrid Dahl Hovland, adm. dir. Nye Veier "
+                                         "og Johan Arnt Vatnan, prosjektdir. Nye "
+                                         "Veier."),
+                    "id": "17854273",
+                    "mime_type": "image/jpeg",
+                    "url": "https://www.ntbinfo.no/data/images/00507/26539909-564d-40dc-8298-d237b964dde9.jpg",
+                }
+            ]
+        }
+        self.assertEqual(item['extra'], expected)
 
 
 class STTBodyTestCase(BaseSolitaTestCase):
@@ -164,16 +185,16 @@ class STTDocumentsTestCase(BaseSolitaTestCase):
             'verlever i markedet. Blant annet innkj&oslash;p, bransjeutvikling, rammebetingelser, markedsf&oslash;ring '
             'og kundeopplevelser. Men det er i hvert fall en ting man kan gj&oslash;re noe med for &aring; unng&aring; '
             'konkurs, og det er &aring; f&oslash;lge godt med p&aring; de man handler med og v&aelig;re tilbakeholden m'
-            'ed kreditter til virksomheter som sliter, r&aring;der Ruud.</p>\n<p>\n<a href="https://www.ntbinfo.no/data'
-            '/images/00390/20b6d51e-3abb-4eff-ae86-c4dfff029a23.jpg">6244 bedrifter har gått overende de siste 12 måned'
-            'ene. Spesielt Detaljhandel, Lagring og Transport merker presset. (foto for fri bruk til saken)</a><br><a h'
-            'ref="https://www.ntbinfo.no/data/images/00749/e303f05c-30ad-4821-8862-d0f1f27d484a.jpg">– Det er spesielt '
-            'noen bransjer som merker presset. Butikkene har for lengst merket kampen mot netthandelen og sliter med la'
-            've marginer, forteller Per Einar Ruud i data- og analyseselskapet Bisnode.</a>\n</p>\n<h2>Dokumenter</h2><'
-            'p>\n<a href="https://www.ntbinfo.no/data/attachments/00203/fa42f1c1-aaa5-4ec1-908d-8b38a100bfab.pptx">Konk'
-            'urser februar 2019.pptx</a>\n</p>\n<h2>Kontacter</h2><p><name>Per Einar Ruud i Bisnode</name><br><title>Kr'
-            'edittøkonom, Bisnode</title><br><phone>+47 92 40 10 04\u2028</phone><br><email>per.einar.ruud@bisnode.com<'
-            '/email></p>\n<p>Les hele denne saken fra <name>Bisnode</name> på NTB info<br><a href="https://www.ntbinfo.'
-            'no/pressemelding/nedgang-men-fortsatt-hoye-konkurstall-med-bransje--og-fylkesoversikt?releaseId=17861325">'
-            'https://www.ntbinfo.no/pressemelding/nedgang-men-fortsatt-hoye-konkurstall-med-bransje--og-fylkesoversikt?'
-            'releaseId=17861325</a></p>')
+            'ed kreditter til virksomheter som sliter, r&aring;der Ruud.</p>\n<p class="ntb-media">\n<a href="https://w'
+            'ww.ntbinfo.no/data/images/00390/20b6d51e-3abb-4eff-ae86-c4dfff029a23.jpg">6244 bedrifter har gått overende'
+            ' de siste 12 månedene. Spesielt Detaljhandel, Lagring og Transport merker presset. (foto for fri bruk til '
+            'saken)</a><br><a href="https://www.ntbinfo.no/data/images/00749/e303f05c-30ad-4821-8862-d0f1f27d484a.jpg">'
+            '– Det er spesielt noen bransjer som merker presset. Butikkene har for lengst merket kampen mot netthandele'
+            'n og sliter med lave marginer, forteller Per Einar Ruud i data- og analyseselskapet Bisnode.</a>\n</p>\n<h'
+            '2>Dokumenter</h2><p>\n<a href="https://www.ntbinfo.no/data/attachments/00203/fa42f1c1-aaa5-4ec1-908d-8b38a'
+            '100bfab.pptx">Konkurser februar 2019.pptx</a>\n</p>\n<h2>Kontacter</h2><p><name>Per Einar Ruud i Bisnode</'
+            'name><br><title>Kredittøkonom, Bisnode</title><br><phone>+47 92 40 10 04\u2028</phone><br><email>per.einar'
+            '.ruud@bisnode.com</email></p>\n<p>Les hele denne saken fra <name>Bisnode</name> på NTB info<br><a href="ht'
+            'tps://www.ntbinfo.no/pressemelding/nedgang-men-fortsatt-hoye-konkurstall-med-bransje--og-fylkesoversikt?re'
+            'leaseId=17861325">https://www.ntbinfo.no/pressemelding/nedgang-men-fortsatt-hoye-konkurstall-med-bransje--'
+            'og-fylkesoversikt?releaseId=17861325</a></p>')

--- a/server/ntb/tests/publish/ntb_nitf_test.py
+++ b/server/ntb/tests/publish/ntb_nitf_test.py
@@ -25,6 +25,7 @@ TEST_ABSTRACT = "This is the abstract"
 TEST_NOT_LEAD = "This should not be lead"
 TEST_EMAILS = ('test1@test.tld', 'test2@example.net', 'test3@example.org')
 ITEM_ID = str(uuid.uuid4())
+NTB_MEDIA_TXT = 'NTBMEDIA TO REMOVE'
 NOW = datetime.datetime.now(datetime.timezone.utc)
 TEST_BODY = """
 <p class="lead" lede="true">""" + TEST_NOT_LEAD + """</p>
@@ -39,6 +40,7 @@ following a general election in Madrid, Spain, July 19, 2016. REUTERS/Andrea Com
 </figure><!-- EMBED END Image {id: "embedded18237840351"} -->
 <h3>intermediate line</h3>
 <p>this element should have a txt class</p>
+<p class="ntb-media"><a url="http://example.net/something.jpg">test</a>""" + NTB_MEDIA_TXT + """</p>
 <!-- EMBED START Video {id: "embedded10005446043"} --><figure>
 <video controls="controls">
 </video>
@@ -193,6 +195,16 @@ ARTICLE = {
         },
         "embedded03": None,
     },
+    "extra": {
+        "ntb_media": [
+            {
+                "id": "1234",
+                "url": "https://www.example.net/ntb_media_test.jpg",
+                "mime_type": "image/jpeg",
+                "description_text": "this is a test ntb media"
+            }
+        ]
+    },
 }
 
 
@@ -247,6 +259,11 @@ class NTBNITFFormatterTest(TestCase):
     def test_body(self):
         # body content
         body_content = self.nitf_xml.find("body/body.content")
+        # we must not have ntb-media <p> element
+        # we can't use the "ntb-media" class, because all classes are changed to
+        # "txt" or "txt-ind", so we use NTB_MEDIA_TXT to check if element is here
+        p_ntb_media_elem = body_content.xpath('p[text()="{}"]'.format(NTB_MEDIA_TXT))
+        self.assertEqual(p_ntb_media_elem, [])
         p_elems = iter(body_content.findall('p'))
         lead = next(p_elems)
         self.assertEqual(lead.get("class"), "lead")
@@ -298,6 +315,13 @@ class NTBNITFFormatterTest(TestCase):
         self.assertEqual(video.find("media-reference").get("source"), "tb42bf38")
         self.assertEqual(video.find("media-caption").text, "\n\nSCRIPT TO FOLLOW\n")
 
+        ntb_media = medias[3]
+        self.assertEqual(ntb_media.get("media-type"), "image")
+        self.assertEqual(ntb_media.get("class"), "prs")
+        self.assertEqual(ntb_media.find("media-reference").get("source"), "https://www.example.net/ntb_media_test.jpg")
+        self.assertEqual(ntb_media.find("media-reference").get("alternate-text"), "http://www.ntbinfo.no/")
+        self.assertEqual(ntb_media.find("media-caption").text, "this is a test ntb media")
+
     def test_sign_off(self):
         a_elems = self.nitf_xml.findall("body/body.end/tagline/a")
         assert len(a_elems) == len(TEST_EMAILS)
@@ -326,13 +350,17 @@ class NTBNITFFormatterTest(TestCase):
         article['abstract'] = ''
         del article['associations']
         article['body_html'] = "<pref:h1><other_pref:body.content><t:t/>toto</other_pref:body.content></pref:h1>"
-        expected = (b'<body.content><p class="lead" lede="true" />toto<p class="txt">'
-                    b'footer text</p></body.content>')
+        expected = (
+            '<body.content><p class="lead" lede="true"/>toto<p class="txt">footer text</p><media media-type="image" cla'
+            'ss="prs"><media-reference mime-type="image/jpeg" alternate-text="http://www.ntbinfo.no/" source="https://w'
+            'ww.example.net/ntb_media_test.jpg"/><media-caption>this is a test ntb media</media-caption></media></body.'
+            'content>'
+        )
         formatter_output = self.formatter.format(article, {'name': 'Test NTBNITF'})
         doc = formatter_output[0]['encoded_item']
         nitf_xml = etree.fromstring(doc)
-        body_content = nitf_xml.find("body/body.content")
-        self.assertEqual(b''.join(etree.tostring(body_content).split()), b''.join(expected.split()))
+        body_content = ' '.join(etree.tostring(nitf_xml.find("body/body.content"), encoding="unicode").split())
+        self.assertEqual(body_content, expected)
 
     @mock.patch.object(SubscribersService, 'generate_sequence_number', lambda self, subscriber: 1)
     def test_single_counter(self):
@@ -341,6 +369,7 @@ class NTBNITFFormatterTest(TestCase):
         article = copy.deepcopy(self.article)
         article['body_html'] = "<p/>"
         del article['associations']
+        del article['extra']
         formatter_output = self.formatter.format(article, {'name': 'Test NTBNITF'})
         doc = formatter_output[0]['encoded_item']
         nitf_xml = etree.fromstring(doc)
@@ -362,18 +391,19 @@ class NTBNITFFormatterTest(TestCase):
             i den canadiske byen Windsor var personlig rekord på <st1:metricconverter productid="1500 meter"
             w:st="on">1500 meter</st1:metricconverter><br></p>
             """
-        expected = b"""\
-            <body.content><p class="lead" lede="true" /><p class="txt-ind">M&#229;let i
-            kortbane-VM som nylig ble avsluttet i den canadiske byen Windsor var personlig rekord p&#229; 1500
-            meter</p><p class="txt">footer text</p><media media-type="image" class="illustrasjonsbilde"><media-referenc
-            e mime-type="image/jpeg" source="test_id" /><media-caption>test feature media</media-caption></media>
-            </body.content>
-            """.replace(b'\n', b'').replace(b' ', b'')
+        expected = (
+            '<body.content> <p class="lead" lede="true"/> <p class="txt-ind">Målet i kortbane-VM som nylig ble avslutte'
+            't i den canadiske byen Windsor var personlig rekord på 1500 meter</p> <p class="txt">footer text</p> <medi'
+            'a media-type="image" class="illustrasjonsbilde"> <media-reference mime-type="image/jpeg" source="test_id"/'
+            '> <media-caption>test feature media</media-caption> </media> <media media-type="image" class="prs"> <media'
+            '-reference mime-type="image/jpeg" alternate-text="http://www.ntbinfo.no/" source="https://www.example.net/'
+            'ntb_media_test.jpg"/> <media-caption>this is a test ntb media</media-caption> </media> </body.content>'
+        )
         formatter_output = self.formatter.format(article, {'name': 'Test NTBNITF'})
         doc = formatter_output[0]['encoded_item']
         nitf_xml = etree.fromstring(doc)
-        body_content = nitf_xml.find("body/body.content")
-        self.assertEqual(etree.tostring(body_content).replace(b'\n', b'').replace(b' ', b''), expected)
+        body_content = ' '.join(etree.tostring(nitf_xml.find("body/body.content"), encoding='unicode').split())
+        self.assertEqual(body_content, expected)
 
     @mock.patch.object(SubscribersService, 'generate_sequence_number', lambda self, subscriber: 1)
     def test_355(self):
@@ -389,7 +419,7 @@ class NTBNITFFormatterTest(TestCase):
         # the test will raise an exception during self.formatter.format if SDNTB-355 bug is still present
         # but we check in addition that media counter is as expected
         media_counter = nitf_xml.find('head').find('meta[@name="NTBBilderAntall"]')
-        self.assertEqual(media_counter.get('content'), '2')
+        self.assertEqual(media_counter.get('content'), '3')
 
     @mock.patch.object(SubscribersService, 'generate_sequence_number', lambda self, subscriber: 1)
     def test_358(self):
@@ -439,7 +469,7 @@ class NTBNITFFormatterTest(TestCase):
         media_counter = nitf_xml.find('head').find('meta[@name="NTBBilderAntall"]')
         # the test will raise an exception during self.formatter.format if SDNTB-390 bug is still present
         # but we check in addition that media counter is as expected (same as for test_355)
-        self.assertEqual(media_counter.get('content'), '2')
+        self.assertEqual(media_counter.get('content'), '3')
 
     @mock.patch.object(SubscribersService, 'generate_sequence_number', lambda self, subscriber: 1)
     def test_pretty_formatting(self):
@@ -464,7 +494,7 @@ class NTBNITFFormatterTest(TestCase):
         formatter_output = self.formatter.format(article, {'name': 'Test NTBNITF'})
         doc = formatter_output[0]['encoded_item']
         body_content = doc[doc.find(b'<body.content>') - 4:doc.find(b'</body.content>') + 15]
-        expected = b"""\
+        expected = (b"""\
     <body.content>
       <p class="lead" lede="true"></p>
       <hl2>test title</hl2>
@@ -479,7 +509,12 @@ class NTBNITFFormatterTest(TestCase):
       <p class="txt-ind">foo</p>
       <p class="txt-ind">bar</p>
       <p class="txt">footer text</p>
-    </body.content>"""
+      <media media-type="image" class="prs">
+        <media-reference mime-type="image/jpeg" alternate-text="http://www.ntbinfo.no/" source"""
+                    b"""="https://www.example.net/ntb_media_test.jpg"/>
+        <media-caption>this is a test ntb media</media-caption>
+      </media>
+    </body.content>""")
         self.assertEqual(body_content, expected, body_content.decode('utf-8'))
 
     def test_filename(self):
@@ -503,7 +538,7 @@ class NTBNITFFormatterTest(TestCase):
         head = self.nitf_xml.find('head')
 
         media_counter = head.find('meta[@name="NTBBilderAntall"]')
-        self.assertEqual(media_counter.get('content'), '3')
+        self.assertEqual(media_counter.get('content'), '4')
         editor = head.find('meta[@name="NTBEditor"]')
         self.assertEqual(editor.get('content'), 'Superdesk')
         kode = head.find('meta[@name="NTBDistribusjonsKode"]')
@@ -548,7 +583,7 @@ class NTBNITFFormatterTest(TestCase):
         # the test will raise an exception during self.formatter.format if SDNTB-396 bug is still present
         # but we check in addition that media counter is as expected (same as for test_355)
         media_counter = nitf_xml.find('head').find('meta[@name="NTBBilderAntall"]')
-        self.assertEqual(media_counter.get('content'), '3')
+        self.assertEqual(media_counter.get('content'), '4')
 
     @mock.patch.object(SubscribersService, 'generate_sequence_number', lambda self, subscriber: 1)
     def test_body_none(self):
@@ -559,17 +594,15 @@ class NTBNITFFormatterTest(TestCase):
         # but we also check that body.content is there
         doc = formatter_output[0]['encoded_item']
         nitf_xml = etree.fromstring(doc)
-        expected = ("""
-        <body.content>
-            <p class="lead" lede="true">This is the abstract</p>
-            <p class="txt">footer text</p>
-            <media media-type="image" class="illustrasjonsbilde">
-                <media-reference mime-type="image/jpeg" source="test_id"/>
-                <media-caption>test feature media</media-caption>
-            </media>
-        </body.content>""").replace('\n', '').replace(' ', '')
-        content = etree.tostring(nitf_xml.find('body/body.content'),
-                                 encoding="unicode").replace('\n', '').replace(' ', '')
+        expected = (
+            '<body.content> <p class="lead" lede="true">This is the abstract</p> <p class="txt">footer text</p> <media '
+            'media-type="image" class="illustrasjonsbilde"> <media-reference mime-type="image/jpeg" source="test_id"/> '
+            '<media-caption>test feature media</media-caption> </media> <media media-type="image" class="prs"> <media-r'
+            'eference mime-type="image/jpeg" alternate-text="http://www.ntbinfo.no/" source="https://www.example.net/nt'
+            'b_media_test.jpg"/> <media-caption>this is a test ntb media</media-caption> </media> </body.content>'
+        )
+        content = ' '.join(etree.tostring(nitf_xml.find('body/body.content'),
+                                          encoding="unicode").split())
         self.assertEqual(content, expected)
 
     @mock.patch.object(SubscribersService, 'generate_sequence_number', lambda self, subscriber: 1)


### PR DESCRIPTION
image are added to associations and embed marquers are set so formatter
(notably NTB NITF) can render those images.

SDNTB-566