### PR TITLE
Sort scheduled output by scheduled time

### DIFF
--- a/client/superdesk.config.js
+++ b/client/superdesk.config.js
@@ -56,7 +56,10 @@ module.exports = function(grunt) {
 
         monitoring: {
             scheduled: {
-                sort: [ 'publish_schedule' ]
+                sort: {
+                    default: 'publish_schedule:asc',
+                    options: [ 'publish_schedule' ]
+                }
             },
         },
 

--- a/client/superdesk.config.js
+++ b/client/superdesk.config.js
@@ -57,8 +57,8 @@ module.exports = function(grunt) {
         monitoring: {
             scheduled: {
                 sort: {
-                    default: 'publish_schedule:asc',
-                    options: [ 'publish_schedule' ]
+                    default: { field: 'publish_schedule', order: 'asc' },
+                    allowed_fields_to_sort: [ 'publish_schedule' ]
                 }
             },
         },


### PR DESCRIPTION
SDNTB-545

This will sort the stage by default, without user intervention.
User can still override this in the UI with the dropdown.

It needs https://github.com/superdesk/superdesk-client-core/pull/2994