### PR TITLE
New planning export template: Group by date

### DIFF
--- a/server/data/planning_export_templates.json
+++ b/server/data/planning_export_templates.json
@@ -1,0 +1,12 @@
+[
+  {
+    "_id": "planning_group_by_date",
+    "name": "group_by_date",
+    "type": "planning",
+    "data": {
+      "slugline": "planning-date",
+      "body_html_template": "planning_group_by_date.html"
+    },
+    "label": "Group by date"
+  }
+]

--- a/server/templates/planning_group_by_date.html
+++ b/server/templates/planning_group_by_date.html
@@ -1,0 +1,32 @@
+{% for year, year_group in items|groupby('planning_date.year') %}
+{% for month, month_group in year_group|groupby('planning_date.month') %}
+{% for day, day_group in month_group|groupby('planning_date.day') %}
+    {% set weekday = day_group[0].planning_date.strftime('%A') %}
+    {% if weekday == 'Monday' %}<h2>Mandag {{day}}/{{month}}</h2>{% endif %}
+    {% if weekday == 'Tuesday' %}<h2>Tirsdag {{day}}/{{month}}</h2>{% endif %}
+    {% if weekday == 'Wednesday' %}<h2>Onsdag {{day}}/{{month}}</h2>{% endif %}
+    {% if weekday == 'Thursday' %}<h2>Torsdag {{day}}/{{month}}</h2>{% endif %}
+    {% if weekday == 'Friday' %}<h2>Fredag {{day}}/{{month}}</h2>{% endif %}
+    {% if weekday == 'Saturday' %}<h2>Lørdag {{day}}/{{month}}</h2>{% endif %}
+    {% if weekday == 'Sunday' %}<h2>Søndag {{day}}/{{month}}</h2>{% endif %}
+    {% for item in day_group %}
+        <h2>{{ item.name or item.headline or item.slugline }}</h2>
+        <p>{{ item.description_text }}
+            {% if item.get('event', {}).get('location') %}
+            &nbsp;Sted: {{ item.event.location[0].name }}.
+            {% endif %}
+            {% if item.get('planning_date', '') != '' %}
+            &nbsp;Tid: {{ item.planning_date | format_datetime(date_format='%H:%M') }}.
+            {% endif %}
+        </p>
+        {% if item.get('ednote', '') != '' %}
+        <p>Til red: {{ item.ednote }}</p>
+        {% endif %}
+        {% if item.coverages %}
+        <p>Dekning: {{ item.coverages | join(', ') }}</p>
+        {% endif %}
+        <p></p>
+    {% endfor %}
+{% endfor %}
+{% endfor %}
+{% endfor %}


### PR DESCRIPTION
SDNTB-585

Each items has the same format than before but they're all grouped by date

Each group has a subheading: `Day of week (in Norwegian) day/month`