### PR TITLE
fix scanpix links

### DIFF
--- a/server/ntb/tests/ping_scanpix_test.py
+++ b/server/ntb/tests/ping_scanpix_test.py
@@ -1,13 +1,20 @@
 
 import os
 import bson
+import copy
 import responses
 
+from unittest.mock import patch
 from flask import json
 from superdesk.tests import TestCase
 from ntb.ping_scanpix import publish_scanpix, SCANPIX_PING_URL, SCANPIX_DOWNLOAD_URL
 
 import ntb.scanpix  # noqa
+
+
+class Media():
+    _id = 'foo'
+    content_type = 'image/jpeg'
 
 
 class PingScanpixTestCase(TestCase):
@@ -29,11 +36,14 @@ class PingScanpixTestCase(TestCase):
         responses.add(responses.GET,
                       SCANPIX_DOWNLOAD_URL.format('editorial', self.item['associations']['featuremedia']['_id']),
                       body=b'', status=200)
+        item = copy.deepcopy(self.item)
+        renditions = item['associations']['featuremedia']['renditions']
+        self.assertNotIn('original', renditions)
         with self.app.app_context():
             self.app.config['SCANPIX_PING_OWNER'] = 'ntb'
             self.app.config['SCANPIX_PING_USERNAME'] = 'foo'
             self.app.config['SCANPIX_PING_PASSWORD'] = 'bar'
-            publish_scanpix(self, item=self.item, foo='foo')
+            publish_scanpix(self, item=item, foo='foo')
         self.assertEqual(2, len(responses.calls))
         self.assertEqual(json.dumps({
             'type': 'articleUsage',
@@ -43,3 +53,16 @@ class PingScanpixTestCase(TestCase):
                 'article_id': 'a3b71dbe-c23b-49d8-8f2b-cbe09e2cff3e',
             },
         }), responses.calls[1].request.body)
+        self.assertIn('original', renditions)
+
+        # publish again, now with image fetched already
+        item = copy.deepcopy(self.item)
+        renditions = item['associations']['featuremedia']['renditions']
+        self.assertNotIn('original', renditions)
+        with self.app.app_context():
+            with patch.object(self.app.media, 'get', return_value=Media()):
+                self.app.config['SCANPIX_PING_OWNER'] = 'ntb'
+                self.app.config['SCANPIX_PING_USERNAME'] = 'foo'
+                self.app.config['SCANPIX_PING_PASSWORD'] = 'bar'
+                publish_scanpix(self, item=item, foo='foo')
+        self.assertIn('original', renditions)


### PR DESCRIPTION
it would only set original rendition when the image wasn't
uploaded in superdesk, but all following calls with same
picture were noops

SDNTB-608 SDNTB-609