### PR TITLE
Updated list view, language override

### DIFF
--- a/client/superdesk.config.js
+++ b/client/superdesk.config.js
@@ -112,7 +112,6 @@ module.exports = function(grunt) {
                 'updated',
                 'state',
                 'scheduledDateTime',
-                'associations',
                 'associatedItems',
                 'versioncreated'
             ]

--- a/client/superdesk.config.js
+++ b/client/superdesk.config.js
@@ -113,6 +113,7 @@ module.exports = function(grunt) {
                 'state',
                 'scheduledDateTime',
                 'associations',
+                'associatedItems',
                 'versioncreated'
             ]
         },

--- a/client/superdesk.config.js
+++ b/client/superdesk.config.js
@@ -129,8 +129,8 @@ module.exports = function(grunt) {
 
         langOverride: {
             'nb': {
-                'Planelement': 'NTB-planer',
-                'Hendelser': 'Nyhetskalender'
+                'Planning item': 'NTB-planer',
+                'Event': 'Nyhetskalender'
             },
             'en': {
                 'ANPA Category': 'Service',

--- a/client/superdesk.config.js
+++ b/client/superdesk.config.js
@@ -129,7 +129,7 @@ module.exports = function(grunt) {
 
         langOverride: {
             'nb': {
-                'Planning item': 'NTB-planer',
+                'Planning Item': 'NTB-planer',
                 'Event': 'Nyhetskalender'
             },
             'en': {

--- a/client/superdesk.config.js
+++ b/client/superdesk.config.js
@@ -105,12 +105,14 @@ module.exports = function(grunt) {
                 'slugline',
                 'takekey',
                 'highlights',
+                'markedDesks',
                 'headline',
                 'provider',
                 'update',
                 'updated',
                 'state',
                 'scheduledDateTime',
+                'associations',
                 'versioncreated'
             ]
         },
@@ -126,6 +128,10 @@ module.exports = function(grunt) {
         defaultRoute: '/workspace/monitoring',
 
         langOverride: {
+            'nb': {
+                'Planelement': 'NTB-planer',
+                'Hendelser': 'Nyhetskalender'
+            },
             'en': {
                 'ANPA Category': 'Service',
                 'ANPA CATEGORY': 'SERVICE'


### PR DESCRIPTION
NTB requested some changes to the Norwegian translation but they'd only work for NTB (like NTB-planer for a Planning item). We'll try with language override.