### PR TITLE
Add the place in Imatrics entities.

### DIFF
--- a/server/ntb/publish/ntb_nitf.py
+++ b/server/ntb/publish/ntb_nitf.py
@@ -183,8 +183,8 @@ class NTBNITFFormatter(NITFFormatter):
 
     def _format_docdata(self, article, docdata):
         super()._format_docdata(article, docdata)
-        state_prov = "ntb_parent"
-        county_dist = "ntb_qcode"
+        state_prov = "name"
+        county_dist = "qcode"
 
         if "slugline" in article:
             key_list = etree.SubElement(docdata, "key-list")
@@ -199,11 +199,15 @@ class NTBNITFFormatter(NITFFormatter):
                     "key": self._get_ntb_slugline(article),
                 },
             )
-        if article.get("profile") and get_content_field(article, "place"):
-            state_prov = "name"
-            county_dist = "qcode"
 
-        for place in article.get("place", []):
+        if article.get("profile") and get_content_field(article, "place"):
+            places = [place for place in article.get("place", []) if place.get("scheme") == "place_custom"]
+            state_prov = "ntb_parent"
+            county_dist = "ntb_qcode"
+        else:
+            places = [place for place in article.get("place", []) if place.get("source") == "imatrics"]
+
+        for place in places:
             evloc = etree.SubElement(docdata, "evloc")
             for key, att in ((state_prov, "state-prov"), (county_dist, "county-dist")):
                 try:

--- a/server/ntb/publish/ntb_nitf_multiservice.py
+++ b/server/ntb/publish/ntb_nitf_multiservice.py
@@ -32,7 +32,7 @@ class NTBNITFMultiServiceFormatter(NTBNITFFormatter):
         imatrics_topics = [
             s
             for s in article.get("subject", [])
-            if s.get("scheme") == "imatrics_topic" and s.get("source") == "imatrics"
+            if s.get("scheme") in ["imatrics_topic", "imatrics_category"] and s.get("source") == "imatrics"
         ]
 
         key_list = etree.SubElement(docdata, "key-list")

--- a/server/ntb/publish/ntb_nitf_multiservice.py
+++ b/server/ntb/publish/ntb_nitf_multiservice.py
@@ -12,7 +12,7 @@ from superdesk.publish.publish_service import PublishService
 from .ntb_nitf import NTBNITFFormatter
 from lxml import etree
 
-imatrics_entities = ["organisation", "person", "event"]
+imatrics_entities = ["organisation", "person", "event", "place"]
 
 
 class NTBNITFMultiServiceFormatter(NTBNITFFormatter):

--- a/server/ntb/publish/ntb_nitf_multiservice.py
+++ b/server/ntb/publish/ntb_nitf_multiservice.py
@@ -12,7 +12,7 @@ from superdesk.publish.publish_service import PublishService
 from .ntb_nitf import NTBNITFFormatter
 from lxml import etree
 
-imatrics_entities = ["organisation", "person", "event", "place"]
+imatrics_entities = ["organisation", "person", "event"]
 
 
 class NTBNITFMultiServiceFormatter(NTBNITFFormatter):

--- a/server/ntb/tests/publish/ntb_event_test.py
+++ b/server/ntb/tests/publish/ntb_event_test.py
@@ -22,7 +22,10 @@ class NTBEventTestCase(TestCase):
             'locality': 'Rhodes',
             'website': 'fubar.com',
             'public': True,
-            'contact_state': 'NSW',
+            'contact_state': {
+                'name': 'NSW'
+                'qcode': 'NSW'
+            },
             'last_name': 'Doe',
             'notes': 'Exceptionally good looking',
             'mobile': [

--- a/server/ntb/tests/publish/ntb_event_test.py
+++ b/server/ntb/tests/publish/ntb_event_test.py
@@ -23,7 +23,7 @@ class NTBEventTestCase(TestCase):
             'website': 'fubar.com',
             'public': True,
             'contact_state': {
-                'name': 'NSW'
+                'name': 'NSW',
                 'qcode': 'NSW'
             },
             'last_name': 'Doe',

--- a/server/ntb/tests/publish/ntb_nitf_test.py
+++ b/server/ntb/tests/publish/ntb_nitf_test.py
@@ -74,7 +74,7 @@ ARTICLE = {
         {
             'scheme': 'place_custom',
             'parent': None,
-            'ntb_parent': None,
+            'ntb_parent': 'Global Parent',
             'name': 'Global',
             'qcode': 'Global',
             'ntb_qcode': 'Global',
@@ -347,6 +347,12 @@ class NTBNITFFormatterTest(TestCase):
                                     "parent": {"nullable": True},
                                 },
                             },
+                        },
+                        "place": {
+                            "enabled": True,
+                            "nullable": False,
+                            "required": True,
+                            "type": "list",
                         },
                     },
                 },


### PR DESCRIPTION
New Requirement:
- if the "place_custom" CV is part of the content profile, we'd use it.
- if the "place_custom" is not in the content profile, the place field will be populated from the iMatrics integration from the "place"