### PR TITLE
[SDNTB-889] fix(Reuters): API token not being cached

### DIFF
--- a/server/ntb/io/feeding_services/ntb_reuters_api.py
+++ b/server/ntb/io/feeding_services/ntb_reuters_api.py
@@ -148,7 +148,7 @@ class NTBReutersHTTPFeedingService(HTTPFeedingService):
             response = self.session.post(
                 url or provider["config"].get("url"),
                 headers=headers,
-                data=data,
+                json=data,
                 timeout=timeout,
             )
         except requests.exceptions.Timeout as exception:
@@ -180,7 +180,6 @@ class NTBReutersHTTPFeedingService(HTTPFeedingService):
             raise IngestApiError.apiParseError(exception, self.provider)
 
     def _generate_auth_token(self, provider):
-        # get_Token...
         auth_url = provider["config"].get("auth_url", None)
         body = {
             "client_id": provider["config"].get("client_id", ""),
@@ -188,7 +187,7 @@ class NTBReutersHTTPFeedingService(HTTPFeedingService):
             "grant_type": "client_credentials",
             "audience": provider["config"].get("audience", ""),
         }
-        response = self.session.post(auth_url, data=body, timeout=30)
+        response = self.session.post(auth_url, json=body, timeout=30)
 
         try:
             response.raise_for_status()

--- a/server/ntb/io/feeding_services/ntb_reuters_api.py
+++ b/server/ntb/io/feeding_services/ntb_reuters_api.py
@@ -8,6 +8,7 @@
 # AUTHORS and LICENSE files distributed with this source code, or
 # at https://www.sourcefabric.org/superdesk/license
 
+from typing import Union
 import superdesk
 import logging
 import datetime
@@ -79,33 +80,25 @@ class NTBReutersHTTPFeedingService(HTTPFeedingService):
         },
     ]
 
-    session = None
+    def __init__(self):
+        super().__init__()
+        self.session = requests.Session()
 
     def _update(self, provider, update):
         items = []
         self.provider = provider
-        self.session = requests.Session()
         parser = self.get_feed_parser(provider)
-        provider_config = self.provider.get("config")
-
-        if not provider_config.get("token") or self.is_token_expired(provider_config):
-            self.auth(provider, provider_config)
-
-        headers = {
-            "Authorization": f'Bearer {provider_config.get("token")}',
-            "Content-Type": "application/json",
-        }
+        provider_config = self.provider.setdefault("config", {})
+        provider_config.setdefault("url", "https://api.reutersconnect.com/content/graphql")
+        provider_config.setdefault("auth_url", "https://auth.thomsonreuters.com/oauth/token")
 
         cursor = ""
         default_last_updated = datetime.datetime.utcnow() - datetime.timedelta(hours=1)
-        data = {}
         while True:
             try:
                 variables = {
                     "cursor": cursor,
-                    "dateRange": provider.get(
-                        "last_updated", default_last_updated
-                    ).strftime("%Y.%m.%d.%H.%M.%S"),
+                    "dateRange": provider.get("last_updated", default_last_updated).strftime("%Y.%m.%d.%H.%M.%S"),
                 }
                 if provider_config.get("query", ""):
                     variables["query"] = provider_config["query"]
@@ -113,38 +106,18 @@ class NTBReutersHTTPFeedingService(HTTPFeedingService):
                 if provider_config.get("channel", ""):
                     variables["channel"] = provider_config["channel"]
 
-                response = self.session.post(
-                    provider_config.get("url"),
-                    headers=headers,
-                    data=json.dumps(
-                        {
-                            "query": self.get_query(provider_config),
-                            "variables": variables,
-                        }
-                    ),
-                    timeout=30,
+                data = self.post_url(
+                    provider, data={"query": self.get_query(provider_config), "variables": variables}
                 )
-                response.raise_for_status()
-                data = response.json()
 
                 for id in self.get_items_id(data):
                     detailed_query = self.get_detailed_query(id)
-                    response = self.session.post(
-                        provider_config.get("url"),
-                        headers=headers,
-                        data=json.dumps({"query": detailed_query}),
-                        timeout=30,
-                    )
-                    response.raise_for_status()
-                    detailed_data = response.json()
+                    detailed_data = self.post_url(provider, data={"query": detailed_query})
                     items.append(parser.parse(detailed_data, provider))
 
-            except requests.exceptions.HTTPError as e:
-                if e.response.status_code == 401:
-                    self.auth(provider, provider_config)
-                else:
-                    logger.error(e)
-                    return
+            except Exception as e:
+                logger.exception(e)
+                raise IngestApiError.apiGeneralError(e, provider=provider)
 
             val = data.get("data", {}).get("search", {})
             if val:
@@ -160,54 +133,76 @@ class NTBReutersHTTPFeedingService(HTTPFeedingService):
         else:
             yield [items]
 
-    def auth(self, provider, provider_config):
-        provider_config.setdefault(
-            "url", "https://api.reutersconnect.com/content/graphql"
-        )
-        provider_config.setdefault(
-            "auth_url", "https://auth.thomsonreuters.com/oauth/token"
-        )
+    def post_url(
+        self, provider: dict, url: Union[str, None] = None, data: Union[dict, None] = None, timeout: int = 30
+    ) -> dict:
+        provider_had_token = True if provider.get("tokens") else False
+        auth_token = self._get_auth_token(provider, update=True)
 
+        headers = {
+            "Authorization": f'Bearer {auth_token}',
+            "Content-Type": "application/json",
+        }
+
+        try:
+            response = self.session.post(
+                url or provider["config"].get("url"),
+                headers=headers,
+                data=data,
+                timeout=timeout,
+            )
+        except requests.exceptions.Timeout as exception:
+            raise IngestApiError.apiTimeoutError(exception, self.provider)
+        except requests.exceptions.ConnectionError as exception:
+            raise IngestApiError.apiConnectionError(exception, self.provider)
+        except requests.exceptions.RequestException as exception:
+            raise IngestApiError.apiRequestError(exception, self.provider)
+        except Exception as exception:
+            raise IngestApiError.apiGeneralError(exception, self.provider)
+
+        if not response.ok:
+            exc = Exception(response.reason)
+            if response.status_code in (401, 403):
+                if provider_had_token:
+                    # We had a token stored already, but it's not working.
+                    # Generate a new one
+                    provider.pop("tokens", None)
+                    return self.post_url(provider, url, data, timeout)
+                raise IngestApiError.apiAuthError(exc, self.provider)
+            elif response.status_code == 404:
+                raise IngestApiError.apiNotFoundError(exc, self.provider)
+            else:
+                raise IngestApiError.apiGeneralError(exc, self.provider)
+
+        try:
+            return response.json()
+        except Exception as exception:
+            raise IngestApiError.apiParseError(exception, self.provider)
+
+    def _generate_auth_token(self, provider):
         # get_Token...
-        auth_url = provider_config.get("auth_url", None)
+        auth_url = provider["config"].get("auth_url", None)
         body = {
-            "client_id": provider_config.get("client_id", ""),
-            "client_secret": provider_config.get("client_secret", ""),
+            "client_id": provider["config"].get("client_id", ""),
+            "client_secret": provider["config"].get("client_secret", ""),
             "grant_type": "client_credentials",
-            "audience": provider_config.get("audience", ""),
+            "audience": provider["config"].get("audience", ""),
         }
         response = self.session.post(auth_url, data=body, timeout=30)
-        response.raise_for_status()
-        if response.status_code == 200:
+
+        try:
+            response.raise_for_status()
             data = response.json()
-            if "token" in provider_config:
-                provider_config["token"] = data.get("access_token")
-            else:
-                provider_config.setdefault("token", data.get("access_token"))
-            if "expires_at" in provider_config:
-                provider_config["expires_at"] = int(
-                    datetime.datetime.now().timestamp()
-                ) + int(data.get("expires_in"))
-            else:
-                provider_config.setdefault(
-                    "expires_at",
-                    int(datetime.datetime.now().timestamp())
-                    + int(data.get("expires_in")),
-                )
-            superdesk.get_resource_service("ingest_providers").update(
-                provider.get("_id"), provider_config, provider
-            )
-        else:
-            raise IngestApiError.apiAuthError()
+            access_token = data.get("access_token")
 
-    def is_token_expired(self, provider_config):
-        """
-        Check whether the token has expired.
-        """
-        current_time = datetime.datetime.now(datetime.timezone.utc).timestamp()
-        expires_at = provider_config.get("expires_at", datetime.datetime.min)
+            if not access_token:
+                raise IngestApiError.apiAuthError(provider=provider)
 
-        return current_time >= expires_at
+            return access_token
+        except Exception as exc:
+            err = IngestApiError.apiAuthError(exc, provider=provider)
+            self.close_provider(provider, err, force=True)
+            raise err
 
     def get_query(self, provider_config):
         query_params = {

--- a/server/ntb/tests/io/feeding_services/ntb_reuters_api_tests.py
+++ b/server/ntb/tests/io/feeding_services/ntb_reuters_api_tests.py
@@ -32,7 +32,7 @@ def gen_provider(auth_token: Union[str, None] = None, created_delta_hrs: Union[i
         },
     }
 
-    if auth_token and created_delta_hrs:
+    if auth_token is not None and created_delta_hrs is not None:
         provider["tokens"] = {"auth_token": auth_token, "created": utcnow() + timedelta(hours=created_delta_hrs)}
 
     return provider
@@ -60,7 +60,7 @@ class NTBReutersAPITestCase(TestCase):
         def assert_auth_request_sent() -> None:
             self.feeding_service.session.post.assert_called_once_with(
                 provider["config"]["auth_url"],
-                data=dict(
+                json=dict(
                     client_id=provider["config"]["client_id"],
                     client_secret=provider["config"]["client_secret"],
                     grant_type="client_credentials",
@@ -102,7 +102,7 @@ class NTBReutersAPITestCase(TestCase):
 
         self.set_post_response(200, {})
         provider = gen_provider("abc123", 10)
-        items = [item for item in self.feeding_service._update(provider, {})]
+        list(self.feeding_service._update(provider, {}))
 
         self.feeding_service.session.post.assert_called_once_with(
             provider["config"]["url"],
@@ -110,7 +110,7 @@ class NTBReutersAPITestCase(TestCase):
                 'Authorization': 'Bearer abc123',
                 'Content-Type': 'application/json'
             },
-            data={
+            json={
                 "query": self.feeding_service.get_query(provider["config"]),
                 "variables": {
                     "cursor": "",

--- a/server/ntb/tests/io/feeding_services/ntb_reuters_api_tests.py
+++ b/server/ntb/tests/io/feeding_services/ntb_reuters_api_tests.py
@@ -1,0 +1,121 @@
+from typing import Union
+from datetime import timedelta
+from unittest import mock
+
+from bson import ObjectId
+
+from superdesk.utc import utcnow
+from superdesk.tests import TestCase
+from superdesk.errors import IngestApiError
+from ntb.io.feeding_services.ntb_reuters_api import NTBReutersHTTPFeedingService
+
+
+PROVIDER_ID = ObjectId()
+now = utcnow()
+
+
+def gen_provider(auth_token: Union[str, None] = None, created_delta_hrs: Union[int, None] = None) -> dict:
+    provider = {
+        "_id": PROVIDER_ID,
+        "name": "",
+        "source": "",
+        "feeding_service": NTBReutersHTTPFeedingService.NAME,
+        "feed_parser": "newsml2",
+        "content_expiry": 2880,
+        "last_updated": now,
+        "config": {
+            "url": "http://localhost:5850/content/graphql",
+            "auth_url": "http://localhost:5850/oauth/token",
+            "client_id": "company_a",
+            "client_secret": "secret_b",
+            "audience": "news_c",
+        },
+    }
+
+    if auth_token and created_delta_hrs:
+        provider["tokens"] = {"auth_token": auth_token, "created": utcnow() + timedelta(hours=created_delta_hrs)}
+
+    return provider
+
+
+class NTBReutersAPITestCase(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.feeding_service = NTBReutersHTTPFeedingService()
+        self.feeding_service.session = mock.MagicMock()
+        self.app.data.insert("ingest_providers", [gen_provider()])
+
+    def set_post_response(self, status_code: int, body: dict):
+        self.feeding_service.session.post = mock.MagicMock()
+        mock_response = mock.MagicMock()
+        mock_response.status_code = status_code
+        mock_response.json.return_value = body
+        self.feeding_service.session.post.return_value = mock_response
+
+    def test_auth_token_renewal(self):
+        """Test auth token endpoint is called and cached with the provider"""
+
+        provider = gen_provider()
+
+        def assert_auth_request_sent() -> None:
+            self.feeding_service.session.post.assert_called_once_with(
+                provider["config"]["auth_url"],
+                data=dict(
+                    client_id=provider["config"]["client_id"],
+                    client_secret=provider["config"]["client_secret"],
+                    grant_type="client_credentials",
+                    audience=provider["config"]["audience"],
+                ),
+                timeout=30
+            )
+
+        # 1. Auth endpoint is called: no current token
+        self.set_post_response(200, {"access_token": "abc123"})
+        token = self.feeding_service._get_auth_token(provider, update=True)
+        self.assertEqual(token, "abc123")
+        assert_auth_request_sent()
+
+        # 2. Auth endpoint is not called: the current token is valid
+        self.set_post_response(200, {"access_token": "abc123"})
+        provider = gen_provider("abc123", 14)
+        token = self.feeding_service._get_auth_token(provider, update=True)
+        self.assertEqual(token, "abc123")
+        self.feeding_service.session.post.assert_not_called()
+
+        # 3. Auth endpoint is called: the current token is expired
+        self.set_post_response(200, {"access_token": "def456"})
+        provider = gen_provider("abc123", -14)
+        token = self.feeding_service._get_auth_token(provider, update=True)
+        self.assertEqual(token, "def456")
+        assert_auth_request_sent()
+
+    def test_failed_auth(self) -> None:
+        """Test auth failure raises IngestApiError"""
+
+        self.set_post_response(401, {})
+        provider = gen_provider()
+        with self.assertRaises(IngestApiError):
+            self.feeding_service._get_auth_token(provider, update=True)
+
+    def test_get_items_request(self):
+        """Test request is sent to the Reuters API with the correct parameters"""
+
+        self.set_post_response(200, {})
+        provider = gen_provider("abc123", 10)
+        items = [item for item in self.feeding_service._update(provider, {})]
+
+        self.feeding_service.session.post.assert_called_once_with(
+            provider["config"]["url"],
+            headers={
+                'Authorization': 'Bearer abc123',
+                'Content-Type': 'application/json'
+            },
+            data={
+                "query": self.feeding_service.get_query(provider["config"]),
+                "variables": {
+                    "cursor": "",
+                    "dateRange": now.strftime("%Y.%m.%d.%H.%M.%S"),
+                }
+            },
+            timeout=30
+        )

--- a/setup.py
+++ b/setup.py
@@ -11,14 +11,18 @@
 
 
 from setuptools import setup, find_packages
-from pip.req import parse_requirements
-from pip.download import PipSession
 import os
 
 SOURCE_FOLDER = 'server'
 LONG_DESCRIPTION = open(os.path.join(SOURCE_FOLDER, 'README.md')).read()
-REQUIREMENTS = [str(ir.req) for ir in parse_requirements('server/requirements.txt', session=PipSession())
-                if not (getattr(ir, 'link', False) or getattr(ir, 'url', False))]
+
+with open("server/requirements.txt", "r") as r:
+    # Continue to use requirements.txt
+    # but replace superdesk-core with setuptools equivalent syntax
+    # This is so we don't have to update customer repos
+    REQUIREMENTS = [
+        line.rsplit("\n", 1)[0] for line in r.readlines() if line.rsplit("\n", 1)[0] and not line.startswith("#")
+    ]
 
 setup(
     name='Superdesk-Server',


### PR DESCRIPTION
### Purpose
The API token code for Reuters ingest was not being cached.

### What has changed
* Remove custom token code and re-use the one from core http feeding service
* Don't use Auth API response to determine token TTL, instead renew every 12hrs or upon auth failure.
* Add tests for Reuters feeding service (previously no tests at all that I could see)
* Fix installing superdesk-ntb server in editable state

Resolves: [SDNTB-889](https://sofab.atlassian.net/browse/SDNTB-889)

[SDNTB-889]: https://sofab.atlassian.net/browse/SDNTB-889?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ